### PR TITLE
Updated GoogleCharts.js json encoding

### DIFF
--- a/GoogleCharts.php
+++ b/GoogleCharts.php
@@ -107,13 +107,13 @@ class GoogleCharts extends Widget
 		if (!empty($this->dataArray))
 		{
 			$js .= "
-				var data = google.visualization.arrayToDataTable(JSON.parse('" . json_encode($this->dataArray) . "'));
+				var data = google.visualization.arrayToDataTable(" . json_encode($this->dataArray) . ");
 				";
 		}
 		else
 		{
 			$js .= "
-				var	data = new google.visualization.DataTable(JSON.parse('" . $this->data . "'));
+				var	data = new google.visualization.DataTable(" . json_encode($this->data) . ");
 				";
 		}
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "fruppel/yii2-googlecharts",
+    "name": "sebathi/yii2-googlecharts",
     "description": "Google Charts widget for Yii2.",
     "keywords": ["yii", "extension", "widget", "google charts", "chart"],
     "type": "yii2-extension",


### PR DESCRIPTION
It does not work if you use ' in labels.
